### PR TITLE
uos: fix bug when dkms status exist  (original_module exists)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dkms (3.1.0-2) unstable; urgency=medium
+
+  * fix bug when dkms status, (original_module exists)
+
+ -- shaoyang <shaoyang@uniontech.com>  Thu, 06 Nov 2025 14:47:59 +0800
+
 dkms (3.1.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/kernel_prerm.d_dkms
+++ b/kernel_prerm.d_dkms
@@ -4,7 +4,11 @@
 inst_kern=$1
 
 if command -v dkms > /dev/null; then
-	dkms status -k "$inst_kern" 2>/dev/null | while IFS=",:/ " read -r name vers _ arch status; do
+	dkms status -k "$inst_kern" 2>/dev/null | while IFS= read -r line; do
+		name=$(echo "$line" | cut -d'/' -f1)
+		vers=$(echo "$line" | cut -d'/' -f2 | cut -d',' -f1)
+		arch=$(echo "$line" | awk -F', ' '{print $3}' | cut -d':' -f1)
+		status=$(echo "$line" | awk -F': ' '{print $2}' | awk '{print $1}')
 		[ "$status" = "installed" ] || continue
 		echo "dkms: removing: $name $vers ($inst_kern) ($arch)" >&2
 		dkms remove -m "$name" -v "$vers" -k "$inst_kern" -a "$arch"


### PR DESCRIPTION
解决dkms status分割字符串时，对于后缀(original_module exists)处理错误的